### PR TITLE
Add palm estate monitoring API and dashboard prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,55 @@
-# Kado
--Flower code from: https://codepen.io/mdusmanansari/pen/BamepLe
+# Jamro Palm Estate & Mill Platform
 
+Jamro adalah prototipe platform monitoring kebun dan pabrik kelapa sawit dengan percepatan waktu simulasi. Monorepo ini berisi API Node.js tanpa dependensi eksternal dan antarmuka web statis modular yang memvisualisasikan hasil feed simulasi.
 
-# Description
-Flower code tiktok trend 
+## Struktur Monorepo
 
-Responsive Web -- bisa langsung disesuikan di file css --> style.css
+```
+apps/
+├── api/   # REST API + SSE untuk data kebun, pabrik, norma HK, biaya
+└── web/   # Dashboard web statis yang memanfaatkan API
+```
 
-# Author
-- Flower Code : Md Usman Ansari (@MdUsmanAnsari)
-- Index Code : Septian Dwi Cahyo (@Septiandwica)
+## Menjalankan Secara Lokal
 
-Thanks to codepan and mdusmanansari
+1. **API**
+
+   ```bash
+   npm run dev:api
+   ```
+
+   Server berjalan pada `http://localhost:4000`.
+
+2. **Web Dashboard**
+
+   ```bash
+   npm run dev:web
+   ```
+
+   Server statis berjalan pada `http://localhost:5173`.
+
+### Akun Uji
+
+| Role      | Email                 | Password    |
+|-----------|-----------------------|-------------|
+| Direktur  | director@example.com  | director123 |
+| Mandor    | mandor@example.com    | mandor123   |
+| Pekerja   | pekerja@example.com   | pekerja123  |
+
+Pengembang dapat melakukan elevasi sementara menggunakan kode `123456` melalui formulir khusus di UI.
+
+## Fitur API
+
+- Login JWT + elevasi pengembang.
+- Manajemen Afdeling & Blok (in-memory store + validasi kode unik).
+- Feed simulasi otomatis (1 hari simulasi tiap 30 detik real) mencakup input mandor, panen, transportasi, dan metrik pabrik.
+- Endpoint agregasi kebun/pabrik dan ringkasan biaya.
+- SSE `/live` untuk update waktu simulasi.
+
+## Dashboard Web
+
+- Modul Monitoring Kebun, Monitoring Pabrik, Panduan Budidaya, Norma HK, dan Cost Produksi.
+- UI tematik dengan KPI cards, daftar afdeling/blok/stasiun, dan highlight percepatan waktu.
+- Konsumsi API langsung tanpa bundler eksternal.
+
+> Catatan: Implementasi ini fokus pada prototipe tanpa database permanen. Seluruh data disimpan secara in-memory dan di-reset ketika server API dimulai ulang.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "api",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "description": "Jamro API server",
+  "scripts": {
+    "start": "node src/main.js",
+    "start:dev": "NODE_ENV=development node src/main.js",
+    "lint": "node --check src/main.js",
+    "build": "echo 'No build step for API'",
+    "test": "node --test"
+  }
+}

--- a/apps/api/src/auth/password.js
+++ b/apps/api/src/auth/password.js
@@ -1,0 +1,9 @@
+import crypto from 'node:crypto';
+
+export function hashPassword(password) {
+  return crypto.createHash('sha256').update(password).digest('hex');
+}
+
+export function verifyPassword(password, hash) {
+  return hashPassword(password) === hash;
+}

--- a/apps/api/src/config.js
+++ b/apps/api/src/config.js
@@ -1,0 +1,7 @@
+export const SIMULATION_REAL_SECONDS_PER_SIM_DAY = Number.parseFloat(process.env.SIM_REAL_SECONDS_PER_SIM_DAY ?? '30');
+export const SIMULATION_TICK_MS = Number.parseInt(process.env.SIM_TICK_MS ?? '1000', 10);
+export const JWT_SECRET = process.env.JWT_SECRET ?? 'development-secret-change-me';
+export const TOKEN_TTL_SECONDS = Number.parseInt(process.env.TOKEN_TTL_SECONDS ?? String(60 * 60 * 12), 10);
+export const PORT = Number.parseInt(process.env.PORT ?? '4000', 10);
+export const HOST = process.env.HOST ?? '0.0.0.0';
+export const CORS_ORIGINS = (process.env.CORS_ORIGINS ?? '*').split(',').map((origin) => origin.trim());

--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,0 +1,35 @@
+import { store } from '../data/store.js';
+import { verifyPassword } from '../auth/password.js';
+import { signToken } from '../utils/jwt.js';
+
+export function login({ email, password }) {
+  if (!email || !password) {
+    throw new Error('Email dan password wajib diisi');
+  }
+  const user = store.findUserByEmail(email);
+  if (!user || !verifyPassword(password, user.passwordHash)) {
+    const err = new Error('Kredensial tidak valid');
+    err.statusCode = 401;
+    throw err;
+  }
+  return {
+    token: signToken({ sub: user.id, role: user.role, name: user.name }),
+    user: {
+      id: user.id,
+      name: user.name,
+      email: user.email,
+      role: user.role,
+    },
+  };
+}
+
+export function devElevate({ code }) {
+  if (code !== '123456') {
+    const err = new Error('Kode pengembang salah');
+    err.statusCode = 403;
+    throw err;
+  }
+  return {
+    token: signToken({ sub: 'u-dev', role: 'PENGEMBANG', name: 'Pengembang' }, 60 * 60),
+  };
+}

--- a/apps/api/src/controllers/estateController.js
+++ b/apps/api/src/controllers/estateController.js
@@ -1,0 +1,112 @@
+import { store } from '../data/store.js';
+
+export function listAfdelings() {
+  return store.listAfdelings().map((afdeling) => ({
+    ...afdeling,
+    blocks: store.listBlocksByAfdeling(afdeling.id),
+  }));
+}
+
+export function createAfdeling(payload) {
+  if (!payload?.kodeUnik || !payload?.nama) {
+    throw createValidationError('Kode unik dan nama wajib diisi');
+  }
+  if (store.afdelings.some((item) => item.kodeUnik === payload.kodeUnik)) {
+    throw createValidationError('Kode unik afdeling sudah dipakai');
+  }
+  return store.createAfdeling({
+    kodeUnik: payload.kodeUnik,
+    nama: payload.nama,
+    lokasi: payload.lokasi ?? '',
+    luasHa: payload.luasHa ?? 0,
+  });
+}
+
+export function getAfdeling(id) {
+  const afdeling = store.getAfdeling(id);
+  if (!afdeling) {
+    const error = new Error('Afdeling tidak ditemukan');
+    error.statusCode = 404;
+    throw error;
+  }
+  const blocks = store.listBlocksByAfdeling(id);
+  const harvestAggregate = store.aggregateHarvest({ afdelingId: id, periode: 'day' });
+  const weather = store.aggregateInputMandor({ afdelingId: id, periode: 'day' });
+  return {
+    ...afdeling,
+    blocks,
+    harvestAggregate,
+    weather,
+  };
+}
+
+export function createBlock(afdelingId, payload) {
+  const afdeling = store.getAfdeling(afdelingId);
+  if (!afdeling) {
+    const error = new Error('Afdeling tidak ditemukan');
+    error.statusCode = 404;
+    throw error;
+  }
+  if (!payload?.kodeUnik || !payload?.nama) {
+    throw createValidationError('Kode unik dan nama blok wajib diisi');
+  }
+  if (store.blocks.some((item) => item.kodeUnik === payload.kodeUnik)) {
+    throw createValidationError('Kode unik blok sudah digunakan');
+  }
+  return store.createBlock(afdelingId, {
+    kodeUnik: payload.kodeUnik,
+    nama: payload.nama,
+    luasHa: payload.luasHa ?? 0,
+    tahunTanam: payload.tahunTanam ?? null,
+    varietas: payload.varietas ?? null,
+  });
+}
+
+export function getBlock(id) {
+  const block = store.getBlock(id);
+  if (!block) {
+    const error = new Error('Blok tidak ditemukan');
+    error.statusCode = 404;
+    throw error;
+  }
+  const harvest = store.listHarvestsByBlock(id);
+  const inputMandor = store.listInputMandor(id);
+  const transport = store.listTransportLogs(id);
+  return { ...block, harvest, inputMandor, transport };
+}
+
+export function listHarvests(query) {
+  const { blok_id: blockId, afdeling_id: afdelingId, from, to } = query;
+  const results = [];
+  for (const record of store.harvests) {
+    if (blockId && record.blokId !== blockId) continue;
+    if (afdelingId) {
+      const block = store.blocks.find((item) => item.id === record.blokId);
+      if (!block || block.afdelingId !== afdelingId) continue;
+    }
+    if (!store.filterByRange(record.tanggal, from, to)) continue;
+    results.push(record);
+  }
+  return results;
+}
+
+export function aggregateHarvest(query) {
+  const { periode = 'day', afdeling_id: afdelingId, blok_id: blockId } = query;
+  return store.aggregateHarvest({ periode, afdelingId, blockId });
+}
+
+export function aggregateWeather(query) {
+  const { periode = 'day', afdeling_id: afdelingId, blok_id: blockId } = query;
+  return store.aggregateInputMandor({ periode, afdelingId, blockId });
+}
+
+export function listTransportLogs(query) {
+  const { blok_id: blockId, from, to } = query;
+  return store.listTransportLogs(blockId, { from, to });
+}
+
+function createValidationError(message) {
+  const error = new Error(message);
+  error.statusCode = 400;
+  return error;
+}

--- a/apps/api/src/controllers/pabrikController.js
+++ b/apps/api/src/controllers/pabrikController.js
@@ -1,0 +1,27 @@
+import { store } from '../data/store.js';
+
+export function listPabrikStations() {
+  return store.listPabriks().map((pabrik) => ({
+    ...pabrik,
+    stations: store.listStations(pabrik.id),
+  }));
+}
+
+export function getStationMetrics(stationId, query) {
+  const station = store.stations.find((item) => item.id === stationId);
+  if (!station) {
+    const error = new Error('Stasiun tidak ditemukan');
+    error.statusCode = 404;
+    throw error;
+  }
+  const { from, to } = query;
+  return {
+    station,
+    metrics: store.listStationMetrics(stationId, { from, to }),
+  };
+}
+
+export function aggregatePabrik(query) {
+  const { periode = 'day', pabrik_id: pabrikId } = query;
+  return store.aggregatePabrik({ periode, pabrikId });
+}

--- a/apps/api/src/controllers/referenceController.js
+++ b/apps/api/src/controllers/referenceController.js
@@ -1,0 +1,26 @@
+import { store } from '../data/store.js';
+
+export function listNormaHK() {
+  return store.listNormaHK();
+}
+
+export function updateNormaHK(id, payload, user) {
+  const record = store.updateNormaHK(id, {
+    pekerjaan: payload.pekerjaan ?? undefined,
+    normaHk: payload.normaHk ?? undefined,
+    satuan: payload.satuan ?? undefined,
+    catatan: payload.catatan ?? undefined,
+    lastUpdatedBy: user?.sub ?? null,
+  });
+  if (!record) {
+    const error = new Error('Norma HK tidak ditemukan');
+    error.statusCode = 404;
+    throw error;
+  }
+  return record;
+}
+
+export function listCostSummary(query) {
+  const { periode } = query;
+  return store.listCostSummary({ periode });
+}

--- a/apps/api/src/data/seed.js
+++ b/apps/api/src/data/seed.js
@@ -1,0 +1,144 @@
+import crypto from 'node:crypto';
+
+const now = new Date();
+
+function hashPassword(password) {
+  return crypto.createHash('sha256').update(password).digest('hex');
+}
+
+export const users = [
+  {
+    id: 'u-director',
+    name: 'Direktur Utama',
+    email: 'director@example.com',
+    role: 'DIREKTUR',
+    passwordHash: hashPassword('director123'),
+  },
+  {
+    id: 'u-mandor',
+    name: 'Mandor A',
+    email: 'mandor@example.com',
+    role: 'MANDOR',
+    passwordHash: hashPassword('mandor123'),
+  },
+  {
+    id: 'u-worker',
+    name: 'Pekerja 1',
+    email: 'pekerja@example.com',
+    role: 'PEKERJA',
+    passwordHash: hashPassword('pekerja123'),
+  },
+  {
+    id: 'u-dev',
+    name: 'Pengembang',
+    email: 'dev@example.com',
+    role: 'PENGEMBANG',
+    passwordHash: hashPassword('dev123456'),
+  },
+];
+
+export const afdelings = [
+  {
+    id: 'afd-01',
+    kodeUnik: 'AFD-01',
+    nama: 'Afdeling Utara',
+    lokasi: 'Koordinat -1.2, 102.3',
+    luasHa: 350,
+    createdAt: now.toISOString(),
+  },
+  {
+    id: 'afd-02',
+    kodeUnik: 'AFD-02',
+    nama: 'Afdeling Selatan',
+    lokasi: 'Koordinat -1.5, 102.1',
+    luasHa: 290,
+    createdAt: now.toISOString(),
+  },
+];
+
+export const blocks = [
+  {
+    id: 'blk-01',
+    kodeUnik: 'AFD01-B01',
+    afdelingId: 'afd-01',
+    nama: 'Blok Utara 1',
+    luasHa: 45,
+    tahunTanam: 2010,
+    varietas: 'Tenera',
+    createdAt: now.toISOString(),
+  },
+  {
+    id: 'blk-02',
+    kodeUnik: 'AFD01-B02',
+    afdelingId: 'afd-01',
+    nama: 'Blok Utara 2',
+    luasHa: 40,
+    tahunTanam: 2012,
+    varietas: 'Tenera',
+    createdAt: now.toISOString(),
+  },
+  {
+    id: 'blk-03',
+    kodeUnik: 'AFD02-B01',
+    afdelingId: 'afd-02',
+    nama: 'Blok Selatan 1',
+    luasHa: 55,
+    tahunTanam: 2009,
+    varietas: 'Dura',
+    createdAt: now.toISOString(),
+  },
+];
+
+export const pabriks = [
+  {
+    id: 'mill-01',
+    nama: 'Pabrik Utama',
+    lokasi: 'Kompleks Pabrik',
+  },
+];
+
+export const stations = [
+  { id: 'st-01', pabrikId: 'mill-01', nama: 'Timbang', urutan: 1 },
+  { id: 'st-02', pabrikId: 'mill-01', nama: 'Sterilizer', urutan: 2 },
+  { id: 'st-03', pabrikId: 'mill-01', nama: 'Thresher', urutan: 3 },
+  { id: 'st-04', pabrikId: 'mill-01', nama: 'Press', urutan: 4 },
+  { id: 'st-05', pabrikId: 'mill-01', nama: 'Clarification', urutan: 5 },
+];
+
+export const normaHK = [
+  {
+    id: 'nhk-01',
+    pekerjaan: 'Panen TBS',
+    normaHk: 1.2,
+    satuan: 'HK/ha',
+    catatan: 'Target harian panen per hektar',
+    lastUpdatedBy: 'u-director',
+    updatedAt: now.toISOString(),
+  },
+  {
+    id: 'nhk-02',
+    pekerjaan: 'Perawatan Jalan',
+    normaHk: 0.4,
+    satuan: 'HK/km',
+    catatan: 'Termasuk perataan dan pengerasan',
+    lastUpdatedBy: 'u-director',
+    updatedAt: now.toISOString(),
+  },
+];
+
+export const costItems = [
+  {
+    id: 'cost-01',
+    kategori: 'Pemupukan',
+    uraian: 'NPK 15-15-15',
+    satuan: 'kg',
+    hargaSatuan: 8500,
+  },
+  {
+    id: 'cost-02',
+    kategori: 'Energi',
+    uraian: 'Bahan bakar boiler',
+    satuan: 'liter',
+    hargaSatuan: 11500,
+  },
+];

--- a/apps/api/src/data/store.js
+++ b/apps/api/src/data/store.js
@@ -1,0 +1,291 @@
+import crypto from 'node:crypto';
+import {
+  users as seedUsers,
+  afdelings as seedAfdelings,
+  blocks as seedBlocks,
+  pabriks as seedPabriks,
+  stations as seedStations,
+  normaHK as seedNormaHK,
+  costItems as seedCostItems,
+} from './seed.js';
+
+function makeId(prefix) {
+  return `${prefix}-${crypto.randomUUID()}`;
+}
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+export class DataStore {
+  constructor() {
+    this.users = clone(seedUsers);
+    this.afdelings = clone(seedAfdelings);
+    this.blocks = clone(seedBlocks);
+    this.inputMandor = [];
+    this.harvests = [];
+    this.transportLogs = [];
+    this.stationMetrics = [];
+    this.pabriks = clone(seedPabriks);
+    this.stations = clone(seedStations);
+    this.normaHK = clone(seedNormaHK);
+    this.costItems = clone(seedCostItems);
+    this.payrolls = [];
+    this.afdelingRequests = [];
+    this.listeners = new Set();
+  }
+
+  subscribe(listener) {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  emit(event, payload) {
+    for (const listener of this.listeners) {
+      listener(event, payload);
+    }
+  }
+
+  findUserByEmail(email) {
+    return this.users.find((user) => user.email.toLowerCase() === email.toLowerCase());
+  }
+
+  addInputMandor(entry) {
+    const record = { id: makeId('input'), ...entry };
+    this.inputMandor.push(record);
+    this.emit('inputMandor', record);
+    return record;
+  }
+
+  addHarvest(entry) {
+    const record = { id: makeId('harvest'), ...entry };
+    this.harvests.push(record);
+    this.emit('harvest', record);
+    return record;
+  }
+
+  addTransportLog(entry) {
+    const record = { id: makeId('transport'), ...entry };
+    this.transportLogs.push(record);
+    this.emit('transport', record);
+    return record;
+  }
+
+  addStationMetric(entry) {
+    const record = { id: makeId('metric'), ...entry };
+    this.stationMetrics.push(record);
+    this.emit('stationMetric', record);
+    return record;
+  }
+
+  createAfdeling(payload) {
+    const record = {
+      id: makeId('afd'),
+      kodeUnik: payload.kodeUnik,
+      nama: payload.nama,
+      lokasi: payload.lokasi,
+      luasHa: payload.luasHa,
+      createdAt: new Date().toISOString(),
+    };
+    this.afdelings.push(record);
+    this.emit('afdeling', record);
+    return record;
+  }
+
+  createBlock(afdelingId, payload) {
+    const record = {
+      id: makeId('blk'),
+      afdelingId,
+      kodeUnik: payload.kodeUnik,
+      nama: payload.nama,
+      luasHa: payload.luasHa,
+      tahunTanam: payload.tahunTanam,
+      varietas: payload.varietas,
+      createdAt: new Date().toISOString(),
+    };
+    this.blocks.push(record);
+    this.emit('block', record);
+    return record;
+  }
+
+  archiveBlock(blockId) {
+    const block = this.blocks.find((item) => item.id === blockId);
+    if (!block) return null;
+    block.archivedAt = new Date().toISOString();
+    this.emit('blockArchived', block);
+    return block;
+  }
+
+  updateNormaHK(id, payload) {
+    const record = this.normaHK.find((item) => item.id === id);
+    if (!record) return null;
+    Object.assign(record, payload, { updatedAt: new Date().toISOString() });
+    this.emit('normaHK', record);
+    return record;
+  }
+
+  listAfdelings() {
+    return clone(this.afdelings);
+  }
+
+  listBlocksByAfdeling(afdelingId) {
+    return this.blocks.filter((block) => block.afdelingId === afdelingId && !block.archivedAt).map(clone);
+  }
+
+  getAfdeling(id) {
+    return clone(this.afdelings.find((item) => item.id === id));
+  }
+
+  getBlock(id) {
+    return clone(this.blocks.find((item) => item.id === id));
+  }
+
+  listHarvestsByBlock(blockId, { from, to } = {}) {
+    return this.harvests.filter((item) => item.blokId === blockId && this.filterByRange(item.tanggal, from, to)).map(clone);
+  }
+
+  listInputMandor(blockId, { from, to } = {}) {
+    return this.inputMandor.filter((item) => item.blokId === blockId && this.filterByRange(item.tanggal, from, to)).map(clone);
+  }
+
+  listTransportLogs(blockId, { from, to } = {}) {
+    return this.transportLogs
+      .filter((item) => (!blockId || item.blokId === blockId) && this.filterByRange(item.waktu, from, to))
+      .map(clone);
+  }
+
+  listStationMetrics(stationId, { from, to } = {}) {
+    return this.stationMetrics.filter((item) => item.stasiunId === stationId && this.filterByRange(item.waktu, from, to)).map(clone);
+  }
+
+  listStations(pabrikId) {
+    return this.stations.filter((station) => station.pabrikId === pabrikId).map(clone);
+  }
+
+  listPabriks() {
+    return clone(this.pabriks);
+  }
+
+  listNormaHK() {
+    return clone(this.normaHK);
+  }
+
+  listCostSummary({ periode } = {}) {
+    const grouped = new Map();
+    for (const item of this.costItems) {
+      const key = item.kategori;
+      const current = grouped.get(key) ?? { kategori: key, total: 0, items: [] };
+      current.items.push({ ...item });
+      current.total += item.hargaSatuan;
+      grouped.set(key, current);
+    }
+    return Array.from(grouped.values());
+  }
+
+  filterByRange(timestamp, from, to) {
+    const time = new Date(timestamp).getTime();
+    if (Number.isNaN(time)) return false;
+    if (from && time < new Date(from).getTime()) return false;
+    if (to && time > new Date(to).getTime()) return false;
+    return true;
+  }
+
+  aggregateHarvest({ periode = 'day', afdelingId, blockId }) {
+    const grouping = new Map();
+    for (const record of this.harvests) {
+      if (afdelingId && this.blocks.find((block) => block.id === record.blokId)?.afdelingId !== afdelingId) continue;
+      if (blockId && record.blokId !== blockId) continue;
+      const key = this.makePeriodKey(record.tanggal, periode);
+      if (!key) continue;
+      const current = grouping.get(key) ?? { periode: key, tbsTotalKg: 0, brondolanKg: 0 };
+      current.tbsTotalKg += record.tbsKg;
+      current.brondolanKg += record.brondolanKg ?? 0;
+      grouping.set(key, current);
+    }
+    return Array.from(grouping.values()).sort((a, b) => a.periode.localeCompare(b.periode));
+  }
+
+  aggregateInputMandor({ periode = 'day', afdelingId, blockId }) {
+    const grouping = new Map();
+    for (const record of this.inputMandor) {
+      const block = this.blocks.find((item) => item.id === record.blokId);
+      if (!block) continue;
+      if (afdelingId && block.afdelingId !== afdelingId) continue;
+      if (blockId && record.blokId !== blockId) continue;
+      const key = this.makePeriodKey(record.tanggal, periode);
+      const current = grouping.get(key) ?? {
+        periode: key,
+        curahHujanTotal: 0,
+        suhuTotal: 0,
+        kelembapanTotal: 0,
+        jalanBaik: 0,
+        jalanBuruk: 0,
+        count: 0,
+      };
+      current.curahHujanTotal += record.curahHujanMm ?? 0;
+      current.suhuTotal += record.suhuC ?? 0;
+      current.kelembapanTotal += record.kelembapanTanahPct ?? 0;
+      current.jalanBaik += record.statusJalan === 'baik' ? 1 : 0;
+      current.jalanBuruk += record.statusJalan === 'buruk' ? 1 : 0;
+      current.count += 1;
+      grouping.set(key, current);
+    }
+    return Array.from(grouping.values()).map((item) => ({
+      periode: item.periode,
+      curahHujanAvg: item.count ? item.curahHujanTotal / item.count : 0,
+      suhuAvg: item.count ? item.suhuTotal / item.count : 0,
+      kelembapanAvg: item.count ? item.kelembapanTotal / item.count : 0,
+      jalanBaik: item.jalanBaik,
+      jalanBuruk: item.jalanBuruk,
+      observasi: item.count,
+    })).sort((a, b) => a.periode.localeCompare(b.periode));
+  }
+
+  aggregatePabrik({ periode = 'day', pabrikId }) {
+    const grouping = new Map();
+    for (const record of this.stationMetrics) {
+      const station = this.stations.find((item) => item.id === record.stasiunId);
+      if (!station) continue;
+      if (pabrikId && station.pabrikId !== pabrikId) continue;
+      const key = this.makePeriodKey(record.waktu, periode);
+      const current = grouping.get(key) ?? {
+        periode: key,
+        throughputTotal: 0,
+        rendemenCpoTotal: 0,
+        rendemenPkoTotal: 0,
+        lossesTotal: 0,
+        energiTotal: 0,
+        count: 0,
+      };
+      current.throughputTotal += record.throughputTph ?? 0;
+      current.rendemenCpoTotal += record.rendemenCpoPct ?? 0;
+      current.rendemenPkoTotal += record.rendemenPkoPct ?? 0;
+      current.lossesTotal += record.lossesPct ?? 0;
+      current.energiTotal += record.energiKwh ?? 0;
+      current.count += 1;
+      grouping.set(key, current);
+    }
+    return Array.from(grouping.values()).map((item) => ({
+      periode: item.periode,
+      throughputAvg: item.count ? item.throughputTotal / item.count : 0,
+      rendemenCpoAvg: item.count ? item.rendemenCpoTotal / item.count : 0,
+      rendemenPkoAvg: item.count ? item.rendemenPkoTotal / item.count : 0,
+      lossesAvg: item.count ? item.lossesTotal / item.count : 0,
+      energiTotal: item.energiTotal,
+    })).sort((a, b) => a.periode.localeCompare(b.periode));
+  }
+
+  makePeriodKey(timestamp, periode) {
+    const date = new Date(timestamp);
+    if (Number.isNaN(date.getTime())) return null;
+    const year = date.getUTCFullYear();
+    const month = `${date.getUTCMonth() + 1}`.padStart(2, '0');
+    const day = `${date.getUTCDate()}`.padStart(2, '0');
+    if (periode === 'day') return `${year}-${month}-${day}`;
+    if (periode === 'month') return `${year}-${month}`;
+    if (periode === 'year') return `${year}`;
+    return null;
+  }
+}
+
+export const store = new DataStore();

--- a/apps/api/src/data/store.js
+++ b/apps/api/src/data/store.js
@@ -230,15 +230,18 @@ export class DataStore {
       current.count += 1;
       grouping.set(key, current);
     }
-    return Array.from(grouping.values()).map((item) => ({
-      periode: item.periode,
-      curahHujanAvg: item.count ? item.curahHujanTotal / item.count : 0,
-      suhuAvg: item.count ? item.suhuTotal / item.count : 0,
-      kelembapanAvg: item.count ? item.kelembapanTotal / item.count : 0,
-      jalanBaik: item.jalanBaik,
-      jalanBuruk: item.jalanBuruk,
-      observasi: item.count,
-    })).sort((a, b) => a.periode.localeCompare(b.periode));
+    return Array.from(grouping.values())
+      .map((item) => ({
+        periode: item.periode,
+        curahHujanTotal: item.curahHujanTotal,
+        curahHujanAvg: item.count ? item.curahHujanTotal / item.count : 0,
+        suhuAvg: item.count ? item.suhuTotal / item.count : 0,
+        kelembapanAvg: item.count ? item.kelembapanTotal / item.count : 0,
+        jalanBaik: item.jalanBaik,
+        jalanBuruk: item.jalanBuruk,
+        observasi: item.count,
+      }))
+      .sort((a, b) => a.periode.localeCompare(b.periode));
   }
 
   aggregatePabrik({ periode = 'day', pabrikId }) {

--- a/apps/api/src/main.js
+++ b/apps/api/src/main.js
@@ -1,0 +1,205 @@
+import http from 'node:http';
+import { URL } from 'node:url';
+import { HOST, PORT, CORS_ORIGINS } from './config.js';
+import { Router } from './routes/router.js';
+import { login, devElevate } from './controllers/authController.js';
+import {
+  listAfdelings,
+  createAfdeling,
+  getAfdeling,
+  createBlock,
+  getBlock,
+  listHarvests,
+  aggregateHarvest,
+  aggregateWeather,
+  listTransportLogs,
+} from './controllers/estateController.js';
+import { listPabrikStations, getStationMetrics, aggregatePabrik } from './controllers/pabrikController.js';
+import { listNormaHK, updateNormaHK, listCostSummary } from './controllers/referenceController.js';
+import { verifyToken } from './utils/jwt.js';
+import { store } from './data/store.js';
+import { SimulationClock } from './sim/clock.js';
+import { DataGenerator } from './sim/generator.js';
+import { EventStream } from './services/eventStream.js';
+
+const router = new Router();
+const clock = new SimulationClock({});
+const generator = new DataGenerator(clock);
+const eventStream = new EventStream({ store, clock });
+clock.start();
+generator.start();
+
+const allowOriginHeader = CORS_ORIGINS.includes('*') ? '*' : null;
+
+router.register('POST', '/auth/login', async ({ body }) => ({ status: 200, data: login(body) }));
+router.register('POST', '/auth/dev-elevate', async ({ body }) => ({ status: 200, data: devElevate(body) }));
+
+router.register('GET', '/afdelings', async () => ({ status: 200, data: listAfdelings() }), { auth: true });
+router.register('POST', '/afdelings', async ({ body }) => ({ status: 201, data: createAfdeling(body) }), {
+  auth: true,
+  roles: ['DIREKTUR', 'PENGEMBANG'],
+});
+router.register('GET', '/afdelings/:id', async ({ params }) => ({ status: 200, data: getAfdeling(params.id) }), {
+  auth: true,
+});
+router.register(
+  'POST',
+  '/afdelings/:id/blocks',
+  async ({ params, body }) => ({ status: 201, data: createBlock(params.id, body) }),
+  { auth: true, roles: ['DIREKTUR', 'PENGEMBANG'] },
+);
+router.register('GET', '/blocks/:id', async ({ params }) => ({ status: 200, data: getBlock(params.id) }), { auth: true });
+
+router.register('GET', '/harvest', async ({ query }) => ({ status: 200, data: listHarvests(query) }), { auth: true });
+router.register('GET', '/harvest/aggregate', async ({ query }) => ({ status: 200, data: aggregateHarvest(query) }), {
+  auth: true,
+});
+router.register('GET', '/metrics/kebun', async ({ query }) => ({ status: 200, data: aggregateWeather(query) }), {
+  auth: true,
+});
+router.register('GET', '/transport/logs', async ({ query }) => ({ status: 200, data: listTransportLogs(query) }), {
+  auth: true,
+});
+
+router.register('GET', '/pabrik/stations', async () => ({ status: 200, data: listPabrikStations() }), { auth: true });
+router.register(
+  'GET',
+  '/pabrik/stations/:id/metrics',
+  async ({ params, query }) => ({ status: 200, data: getStationMetrics(params.id, query) }),
+  { auth: true },
+);
+router.register('GET', '/pabrik/aggregate', async ({ query }) => ({ status: 200, data: aggregatePabrik(query) }), {
+  auth: true,
+});
+
+router.register('GET', '/norma-hk', async () => ({ status: 200, data: listNormaHK() }), { auth: true });
+router.register(
+  'PUT',
+  '/norma-hk/:id',
+  async ({ params, body, user }) => ({ status: 200, data: updateNormaHK(params.id, body, user) }),
+  { auth: true, roles: ['DIREKTUR', 'PENGEMBANG'] },
+);
+
+router.register('GET', '/cost/summary', async ({ query }) => ({ status: 200, data: listCostSummary(query) }), {
+  auth: true,
+});
+
+router.register('GET', '/live', async ({ res }) => {
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    Connection: 'keep-alive',
+  });
+  eventStream.addClient(res);
+  return { stream: true };
+});
+
+const server = http.createServer(async (req, res) => {
+  try {
+    setCorsHeaders(req, res);
+    if (req.method === 'OPTIONS') {
+      res.writeHead(204);
+      res.end();
+      return;
+    }
+    const url = new URL(req.url, `http://${req.headers.host}`);
+    const route = router.match(req.method, url.pathname);
+    if (!route) {
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ message: 'Not Found' }));
+      return;
+    }
+
+    let user = null;
+    if (route.options?.auth) {
+      user = authenticate(req);
+      if (route.options.roles && !route.options.roles.includes(user.role)) {
+        const error = new Error('Tidak memiliki akses');
+        error.statusCode = 403;
+        throw error;
+      }
+    }
+
+    const context = {
+      req,
+      res,
+      params: route.params,
+      query: Object.fromEntries(url.searchParams.entries()),
+      body: await parseBody(req),
+      user,
+    };
+
+    const result = await route.handler(context);
+    if (result?.stream) {
+      return;
+    }
+    const status = result?.status ?? 200;
+    const data = result?.data ?? null;
+    res.writeHead(status, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ data }));
+  } catch (error) {
+    const statusCode = error.statusCode ?? 500;
+    res.writeHead(statusCode, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ message: error.message ?? 'Internal Server Error' }));
+  }
+});
+
+server.listen(PORT, HOST, () => {
+  console.log(`API server running at http://${HOST}:${PORT}`);
+});
+
+function setCorsHeaders(req, res) {
+  const origin = req.headers.origin;
+  if (allowOriginHeader) {
+    res.setHeader('Access-Control-Allow-Origin', allowOriginHeader);
+  } else if (origin && CORS_ORIGINS.includes(origin)) {
+    res.setHeader('Access-Control-Allow-Origin', origin);
+  }
+  res.setHeader('Access-Control-Allow-Methods', 'GET,POST,PUT,OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type,Authorization');
+  res.setHeader('Access-Control-Allow-Credentials', 'true');
+}
+
+async function parseBody(req) {
+  if (req.method === 'GET' || req.method === 'DELETE') {
+    return null;
+  }
+  const chunks = [];
+  for await (const chunk of req) {
+    chunks.push(chunk);
+  }
+  if (!chunks.length) {
+    return {};
+  }
+  const raw = Buffer.concat(chunks).toString('utf8');
+  if (!raw) return {};
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    throw new Error('Payload tidak valid');
+  }
+}
+
+function authenticate(req) {
+  const header = req.headers.authorization;
+  if (!header) {
+    const error = new Error('Token diperlukan');
+    error.statusCode = 401;
+    throw error;
+  }
+  const [, token] = header.split(' ');
+  try {
+    const payload = verifyToken(token);
+    const user = store.users.find((item) => item.id === payload.sub);
+    if (!user) {
+      const err = new Error('Pengguna tidak ditemukan');
+      err.statusCode = 401;
+      throw err;
+    }
+    return { ...payload, role: payload.role ?? user.role };
+  } catch (error) {
+    const err = new Error('Token tidak valid');
+    err.statusCode = 401;
+    throw err;
+  }
+}

--- a/apps/api/src/routes/router.js
+++ b/apps/api/src/routes/router.js
@@ -1,0 +1,42 @@
+function compilePath(path) {
+  const segments = path.split('/').filter(Boolean);
+  const keys = [];
+  const pattern = segments
+    .map((segment) => {
+      if (segment.startsWith(':')) {
+        keys.push(segment.slice(1));
+        return '([^/]+)';
+      }
+      return segment.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    })
+    .join('/');
+  const regex = new RegExp(`^/${pattern}${path.endsWith('/') ? '' : '$'}`);
+  return { regex, keys };
+}
+
+export class Router {
+  constructor() {
+    this.routes = [];
+  }
+
+  register(method, path, handler, options = {}) {
+    const { regex, keys } = compilePath(path);
+    this.routes.push({ method: method.toUpperCase(), path, regex, keys, handler, options });
+  }
+
+  match(method, pathname) {
+    const upper = method.toUpperCase();
+    for (const route of this.routes) {
+      if (route.method !== upper) continue;
+      const match = pathname.match(route.regex);
+      if (match) {
+        const params = {};
+        route.keys.forEach((key, index) => {
+          params[key] = decodeURIComponent(match[index + 1]);
+        });
+        return { ...route, params };
+      }
+    }
+    return null;
+  }
+}

--- a/apps/api/src/services/eventStream.js
+++ b/apps/api/src/services/eventStream.js
@@ -1,0 +1,29 @@
+export class EventStream {
+  constructor({ store, clock }) {
+    this.store = store;
+    this.clock = clock;
+    this.clients = new Set();
+    this.unsubscribeStore = this.store.subscribe((event, payload) => {
+      this.broadcast(event, payload);
+    });
+    this.clock.subscribe((time) => {
+      this.broadcast('tick', { now: time.toISOString() });
+    });
+  }
+
+  addClient(res) {
+    this.clients.add(res);
+    res.on('close', () => {
+      this.clients.delete(res);
+    });
+    res.write(`event: welcome\n`);
+    res.write(`data: ${JSON.stringify({ message: 'connected', now: new Date().toISOString() })}\n\n`);
+  }
+
+  broadcast(event, payload) {
+    const data = `event: ${event}\n` + `data: ${JSON.stringify(payload)}\n\n`;
+    for (const client of this.clients) {
+      client.write(data);
+    }
+  }
+}

--- a/apps/api/src/sim/clock.js
+++ b/apps/api/src/sim/clock.js
@@ -1,0 +1,41 @@
+import { SIMULATION_REAL_SECONDS_PER_SIM_DAY, SIMULATION_TICK_MS } from '../config.js';
+
+const MS_PER_DAY = 86_400_000;
+const ratio = MS_PER_DAY / (SIMULATION_REAL_SECONDS_PER_SIM_DAY * 1000);
+
+export class SimulationClock {
+  constructor({ startSimTime } = {}) {
+    this.startRealTime = Date.now();
+    this.startSimTime = startSimTime ?? Date.UTC(2024, 0, 1, 0, 0, 0);
+    this.interval = null;
+    this.listeners = new Set();
+  }
+
+  get now() {
+    const elapsedRealMs = Date.now() - this.startRealTime;
+    const elapsedSimMs = elapsedRealMs * ratio;
+    return new Date(this.startSimTime + elapsedSimMs);
+  }
+
+  subscribe(listener) {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  start() {
+    if (this.interval) return;
+    this.interval = setInterval(() => {
+      const current = this.now;
+      for (const listener of this.listeners) {
+        listener(current);
+      }
+    }, SIMULATION_TICK_MS).unref?.();
+  }
+
+  stop() {
+    if (this.interval) {
+      clearInterval(this.interval);
+      this.interval = null;
+    }
+  }
+}

--- a/apps/api/src/sim/generator.js
+++ b/apps/api/src/sim/generator.js
@@ -1,0 +1,79 @@
+import { store } from '../data/store.js';
+
+function randomBetween(min, max, fixed = 2) {
+  const value = Math.random() * (max - min) + min;
+  return Number.parseFloat(value.toFixed(fixed));
+}
+
+export class DataGenerator {
+  constructor(clock) {
+    this.clock = clock;
+    this.lastGeneratedDay = null;
+  }
+
+  start() {
+    this.clock.subscribe((simTime) => this.handleTick(simTime));
+  }
+
+  handleTick(simTime) {
+    const dayKey = simTime.toISOString().slice(0, 10);
+    if (dayKey === this.lastGeneratedDay) {
+      return;
+    }
+    this.generateForDay(simTime);
+    this.lastGeneratedDay = dayKey;
+  }
+
+  generateForDay(simTime) {
+    const isoDate = simTime.toISOString();
+    for (const block of store.blocks) {
+      const curahHujan = randomBetween(3, 25);
+      const suhu = randomBetween(24, 34);
+      const kelembapan = randomBetween(55, 80);
+      store.addInputMandor({
+        blokId: block.id,
+        tanggal: isoDate,
+        curahHujanMm: curahHujan,
+        suhuC: suhu,
+        kelembapanTanahPct: kelembapan,
+        statusJalan: Math.random() > 0.2 ? 'baik' : 'buruk',
+        catatan: 'Data simulasi otomatis',
+      });
+
+      const tbsKg = randomBetween(5000, 15000, 0);
+      const brondolanKg = randomBetween(200, 800, 0);
+      store.addHarvest({
+        blokId: block.id,
+        tanggal: isoDate,
+        tbsKg,
+        brondolanKg,
+        jjPct: randomBetween(15, 25),
+        keterangan: 'Hasil panen simulasi',
+      });
+
+      store.addTransportLog({
+        blokId: block.id,
+        waktu: isoDate,
+        kendaraanId: `TRK-${Math.floor(Math.random() * 10) + 1}`,
+        beratTbsKg: tbsKg * 0.95,
+        tujuanPabrikId: 'mill-01',
+        rute: ['blok', 'jalan utama', 'pabrik'],
+        status: 'dikirim',
+      });
+    }
+
+    for (const station of store.stations) {
+      store.addStationMetric({
+        stasiunId: station.id,
+        waktu: isoDate,
+        throughputTph: randomBetween(10, 40),
+        rendemenCpoPct: randomBetween(20, 25),
+        rendemenPkoPct: randomBetween(3, 5),
+        lossesPct: randomBetween(1, 3),
+        suhuC: randomBetween(80, 110),
+        tekananBar: randomBetween(1.5, 3.5),
+        energiKwh: randomBetween(1500, 2500, 0),
+      });
+    }
+  }
+}

--- a/apps/api/src/utils/jwt.js
+++ b/apps/api/src/utils/jwt.js
@@ -1,0 +1,51 @@
+import crypto from 'node:crypto';
+import { JWT_SECRET, TOKEN_TTL_SECONDS } from '../config.js';
+
+function base64UrlEncode(buffer) {
+  return Buffer.from(buffer)
+    .toString('base64')
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+}
+
+function base64UrlDecode(str) {
+  const pad = 4 - (str.length % 4 || 4);
+  const normalized = str.replace(/-/g, '+').replace(/_/g, '/') + '='.repeat(pad % 4);
+  return Buffer.from(normalized, 'base64').toString('utf8');
+}
+
+export function signToken(payload, ttlSeconds = TOKEN_TTL_SECONDS) {
+  const header = { alg: 'HS256', typ: 'JWT' };
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const body = {
+    ...payload,
+    iat: nowSeconds,
+    exp: nowSeconds + ttlSeconds,
+  };
+  const headerSegment = base64UrlEncode(JSON.stringify(header));
+  const payloadSegment = base64UrlEncode(JSON.stringify(body));
+  const content = `${headerSegment}.${payloadSegment}`;
+  const signature = crypto.createHmac('sha256', JWT_SECRET).update(content).digest('base64url');
+  return `${content}.${signature}`;
+}
+
+export function verifyToken(token) {
+  if (!token) {
+    throw new Error('Missing token');
+  }
+  const [headerSegment, payloadSegment, signature] = token.split('.');
+  if (!headerSegment || !payloadSegment || !signature) {
+    throw new Error('Invalid token');
+  }
+  const content = `${headerSegment}.${payloadSegment}`;
+  const expected = crypto.createHmac('sha256', JWT_SECRET).update(content).digest('base64url');
+  if (!crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(expected))) {
+    throw new Error('Invalid signature');
+  }
+  const payload = JSON.parse(base64UrlDecode(payloadSegment));
+  if (payload.exp && Math.floor(Date.now() / 1000) > payload.exp) {
+    throw new Error('Token expired');
+  }
+  return payload;
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "web",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "description": "Jamro monitoring dashboard",
+  "scripts": {
+    "dev": "node server.js",
+    "lint": "node --check public/assets/main.js",
+    "build": "echo 'Static build already in public directory'",
+    "test": "echo 'No tests for web dashboard'"
+  }
+}

--- a/apps/web/public/assets/main.css
+++ b/apps/web/public/assets/main.css
@@ -102,6 +102,11 @@ body {
   box-shadow: 0 20px 45px rgba(15, 23, 42, 0.4);
 }
 
+.card h2 {
+  margin-top: 0;
+  margin-bottom: 0.35rem;
+}
+
 .muted {
   color: var(--muted);
   font-size: 0.95rem;
@@ -278,6 +283,286 @@ button.primary:hover {
   align-items: center;
 }
 
+.overview-grid {
+  display: grid;
+  grid-template-columns: minmax(260px, 0.9fr) minmax(360px, 1.2fr);
+  gap: 1.5rem;
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.rain-card {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.rain-highlight {
+  display: flex;
+  align-items: baseline;
+  gap: 0.35rem;
+}
+
+.rain-value {
+  font-size: 3rem;
+  font-weight: 700;
+}
+
+.rain-unit {
+  font-size: 1.1rem;
+  color: var(--muted);
+}
+
+.legend {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.dot {
+  display: inline-flex;
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  margin-right: 0.35rem;
+}
+
+.dot.humidity {
+  background: #22d3ee;
+}
+
+.dot.temperature {
+  background: #f87171;
+}
+
+.bar-chart {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.75rem;
+  height: 160px;
+  margin-top: 1.25rem;
+}
+
+.bar {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+  flex: 1;
+  min-width: 28px;
+}
+
+.bar-fill {
+  width: 100%;
+  border-radius: 12px 12px 4px 4px;
+  background: linear-gradient(180deg, rgba(34, 211, 238, 0.8), rgba(56, 189, 248, 0.25));
+  transition: height 0.3s ease;
+  min-height: 6px;
+}
+
+.bar-fill.latest {
+  background: linear-gradient(180deg, #22d3ee, rgba(14, 165, 233, 0.6));
+  box-shadow: 0 0 16px rgba(34, 211, 238, 0.35);
+}
+
+.bar-value,
+.bar-label {
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+.climate-chart-wrap {
+  margin-top: 1rem;
+}
+
+.climate-chart {
+  width: 100%;
+  height: 220px;
+}
+
+.chart-axis {
+  stroke: rgba(148, 163, 184, 0.2);
+  stroke-width: 1;
+}
+
+.line {
+  fill: none;
+  stroke-width: 3;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.line.humidity {
+  stroke: #22d3ee;
+}
+
+.line.temperature {
+  stroke: #f87171;
+}
+
+.chart-point {
+  stroke: rgba(15, 23, 42, 0.8);
+  stroke-width: 2;
+}
+
+.chart-point.humidity {
+  fill: #22d3ee;
+}
+
+.chart-point.temperature {
+  fill: #f87171;
+}
+
+.chart-labels {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.soil-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  margin-top: 1.25rem;
+}
+
+.soil-card {
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 16px;
+  padding: 1.2rem 1.4rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.soil-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.soil-title {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.soil-value {
+  font-size: 1.8rem;
+  font-weight: 700;
+  display: flex;
+  align-items: baseline;
+  gap: 0.35rem;
+}
+
+.soil-value span {
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.status {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.2rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+
+.status.optimal {
+  background: rgba(45, 212, 191, 0.15);
+  border-color: rgba(45, 212, 191, 0.35);
+  color: #5eead4;
+}
+
+.status.warning {
+  background: rgba(250, 204, 21, 0.15);
+  border-color: rgba(250, 204, 21, 0.35);
+  color: #facc15;
+}
+
+.status.critical {
+  background: rgba(248, 113, 113, 0.15);
+  border-color: rgba(248, 113, 113, 0.4);
+  color: #f87171;
+}
+
+.status.muted {
+  background: rgba(148, 163, 184, 0.12);
+  border-color: rgba(148, 163, 184, 0.25);
+  color: var(--muted);
+}
+
+.harvest-grid {
+  display: grid;
+  grid-template-columns: minmax(220px, 0.75fr) minmax(260px, 1fr);
+  gap: 1.5rem;
+  margin-top: 1.5rem;
+  align-items: stretch;
+}
+
+.harvest-highlight {
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 16px;
+  padding: 1.5rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.harvest-label {
+  font-size: 0.85rem;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.harvest-value {
+  font-size: 2.4rem;
+  font-weight: 700;
+  display: flex;
+  align-items: baseline;
+  gap: 0.4rem;
+}
+
+.harvest-value span {
+  font-size: 1rem;
+  color: var(--muted);
+}
+
+.harvest-chart {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.empty-state {
+  border: 1px dashed rgba(148, 163, 184, 0.35);
+  border-radius: 16px;
+  padding: 1.5rem;
+  text-align: center;
+  color: var(--muted);
+}
+
 @media (max-width: 900px) {
   .app {
     grid-template-columns: 1fr;
@@ -299,5 +584,25 @@ button.primary:hover {
 
   .content {
     padding: 1.5rem;
+  }
+}
+
+@media (max-width: 1200px) {
+  .overview-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .harvest-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .bar-chart {
+    gap: 0.5rem;
+  }
+
+  .harvest-value {
+    font-size: 2rem;
   }
 }

--- a/apps/web/public/assets/main.css
+++ b/apps/web/public/assets/main.css
@@ -1,0 +1,303 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --bg: #0f172a;
+  --surface: rgba(15, 23, 42, 0.75);
+  --border: rgba(148, 163, 184, 0.2);
+  --accent: #22d3ee;
+  --accent-soft: rgba(34, 211, 238, 0.1);
+  --text: #e2e8f0;
+  --muted: #94a3b8;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top left, rgba(34, 211, 238, 0.1), transparent 50%),
+    radial-gradient(circle at bottom right, rgba(59, 130, 246, 0.15), transparent 40%),
+    var(--bg);
+  color: var(--text);
+}
+
+.app {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  min-height: 100vh;
+}
+
+.sidebar {
+  padding: 2rem 1.5rem;
+  border-right: 1px solid var(--border);
+  backdrop-filter: blur(24px);
+  background: linear-gradient(180deg, rgba(30, 41, 59, 0.75), rgba(15, 23, 42, 0.95));
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.brand {
+  font-size: 1.75rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.nav {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.nav button {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: inherit;
+  padding: 0.75rem 1rem;
+  text-align: left;
+  border-radius: 12px;
+  font-size: 0.95rem;
+  transition: all 0.2s ease-in-out;
+  cursor: pointer;
+}
+
+.nav button.active,
+.nav button:hover {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.user-badge {
+  margin-top: auto;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.logout-btn {
+  background: rgba(248, 113, 113, 0.15);
+  border: 1px solid rgba(248, 113, 113, 0.4);
+  color: #fca5a5;
+  padding: 0.6rem 1rem;
+  border-radius: 10px;
+  cursor: pointer;
+  font-weight: 600;
+  transition: background 0.2s ease;
+}
+
+.logout-btn:hover {
+  background: rgba(248, 113, 113, 0.25);
+}
+
+.content {
+  padding: 2.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 2rem;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.4);
+}
+
+.muted {
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.divider {
+  height: 1px;
+  background: var(--border);
+  width: 100%;
+  opacity: 0.4;
+}
+
+.hidden {
+  display: none;
+}
+
+h1,
+.h1 {
+  font-size: 1.8rem;
+  margin: 0 0 1rem;
+}
+
+h2 {
+  font-size: 1.3rem;
+  margin-top: 2rem;
+  margin-bottom: 0.75rem;
+}
+
+.form-grid {
+  display: grid;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+label {
+  display: grid;
+  gap: 0.4rem;
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+input,
+select,
+textarea {
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: rgba(15, 23, 42, 0.6);
+  color: inherit;
+  font-size: 1rem;
+}
+
+button.primary {
+  background: linear-gradient(135deg, #22d3ee, #6366f1);
+  border: none;
+  padding: 0.75rem 1.2rem;
+  color: #0f172a;
+  font-weight: 700;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: transform 0.2s ease;
+}
+
+button.primary:hover {
+  transform: translateY(-1px);
+}
+
+.kpi-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.kpi-card {
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 16px;
+  padding: 1rem;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.kpi-title {
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.kpi-value {
+  font-size: 1.4rem;
+  font-weight: 700;
+}
+
+.list {
+  display: grid;
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.list-item {
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 1rem 1.5rem;
+  background: rgba(15, 23, 42, 0.5);
+  display: grid;
+  gap: 0.6rem;
+}
+
+.list-item ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.25rem;
+  color: var(--muted);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(34, 211, 238, 0.12);
+  color: var(--accent);
+  font-size: 0.8rem;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+}
+
+.table th,
+.table td {
+  padding: 0.75rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.table th {
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.alert {
+  padding: 1rem 1.2rem;
+  border-radius: 14px;
+  border: 1px solid rgba(248, 180, 127, 0.3);
+  background: rgba(248, 180, 127, 0.12);
+  color: #fbbf24;
+  margin-top: 1rem;
+}
+
+.flex-between {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.module-header {
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+}
+
+.filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+@media (max-width: 900px) {
+  .app {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    position: sticky;
+    top: 0;
+    z-index: 10;
+  }
+
+  .nav {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .content {
+    padding: 1.5rem;
+  }
+}

--- a/apps/web/public/assets/main.js
+++ b/apps/web/public/assets/main.js
@@ -145,77 +145,207 @@ async function loadModule(moduleId) {
 }
 
 async function loadMonitoring() {
-  const [afdelings, harvest, weather] = await Promise.all([
+  const [afdelings, harvestDaily, weatherDaily, weatherMonthly, harvestMonthly] = await Promise.all([
     apiRequest('/afdelings'),
     apiRequest('/harvest/aggregate?periode=day'),
     apiRequest('/metrics/kebun?periode=day'),
+    apiRequest('/metrics/kebun?periode=month'),
+    apiRequest('/harvest/aggregate?periode=month'),
   ]);
-  state.data.monitoring = { afdelings, harvest, weather };
+  state.data.monitoring = {
+    afdelings,
+    harvestDaily,
+    weatherDaily,
+    weatherMonthly,
+    harvestMonthly,
+  };
 }
 
 function renderMonitoring() {
-  const { afdelings = [], harvest = [], weather = [] } = state.data.monitoring ?? {};
-  const harvestKpi = harvest.slice(-1)[0];
-  const weatherKpi = weather.slice(-1)[0];
+  const {
+    afdelings = [],
+    harvestDaily = [],
+    harvestMonthly = [],
+    weatherDaily = [],
+    weatherMonthly = [],
+  } = state.data.monitoring ?? {};
+
+  const latestWeatherDaily = weatherDaily.at(-1) ?? {};
+  const latestHarvestDaily = harvestDaily.at(-1) ?? {};
+  const latestWeatherMonthly = weatherMonthly.at(-1) ?? {};
+  const latestHarvestMonthly = harvestMonthly.at(-1) ?? {};
+
+  const rainfallMonthlySeries = weatherMonthly
+    .slice(-12)
+    .map((item) => ({
+      label: formatPeriodLabel(item.periode),
+      value: item.curahHujanTotal ?? 0,
+    }));
+
+  const harvestMonthlySeries = harvestMonthly
+    .slice(-12)
+    .map((item) => ({
+      label: formatPeriodLabel(item.periode),
+      value: (item.tbsTotalKg ?? 0) / 1000,
+    }));
+
+  const rainfallStatus = classifyRange(latestWeatherMonthly.curahHujanTotal, {
+    min: 150,
+    max: 250,
+  });
+  const moistureStatus = classifyRange(latestWeatherDaily.kelembapanAvg, {
+    min: 28,
+    max: 35,
+    tolerance: 0.2,
+  });
+  const temperatureStatus = classifyRange(latestWeatherDaily.suhuAvg, {
+    min: 24,
+    max: 32,
+  });
+
+  const totalObservasi = latestWeatherDaily.observasi ?? 0;
+  const jalanBaikPersentase = totalObservasi
+    ? Math.round((latestWeatherDaily.jalanBaik / totalObservasi) * 100)
+    : 0;
+  const jalanStatus = classifyRange(jalanBaikPersentase, {
+    min: 70,
+    max: 100,
+    tolerance: 0.05,
+  });
+
   contentSection.innerHTML = `
     <div class="module-header">
       <div>
         <h1>Monitoring Kebun</h1>
-        <p class="muted">Percepatan waktu aktif, data terbaru diperbarui otomatis.</p>
+        <p class="muted">Data real-time dari simulasi percepatan waktu.</p>
       </div>
       <div class="filters">
         <span class="badge">Sim 1 hari = 30 detik</span>
+        <span class="badge">${formatNumber(afdelings.length)} Afdeling</span>
       </div>
     </div>
-    <div class="kpi-grid">
-      <div class="kpi-card">
-        <span class="kpi-title">TBS Hari Ini</span>
-        <span class="kpi-value">${formatNumber(harvestKpi?.tbsTotalKg ?? 0)} kg</span>
+    <div class="overview-grid">
+      <div class="card rain-card">
+        <div class="card-header">
+          <div>
+            <h2>Curah Hujan Bulanan</h2>
+            <p class="muted">Total akumulasi setiap bulan (mm)</p>
+          </div>
+          ${renderStatusBadge(rainfallStatus)}
+        </div>
+        <div class="rain-highlight">
+          <span class="rain-value">${formatNumber(latestWeatherMonthly.curahHujanTotal ?? 0)}</span>
+          <span class="rain-unit">mm</span>
+        </div>
+        <p class="muted">Optimal 150 – 250 mm/bulan</p>
+        ${renderBarChart(rainfallMonthlySeries, { unit: ' mm', highlightLatest: true })}
       </div>
-      <div class="kpi-card">
-        <span class="kpi-title">Brondolan</span>
-        <span class="kpi-value">${formatNumber(harvestKpi?.brondolanKg ?? 0)} kg</span>
-      </div>
-      <div class="kpi-card">
-        <span class="kpi-title">Curah Hujan Rata-rata</span>
-        <span class="kpi-value">${formatNumber(weatherKpi?.curahHujanAvg ?? 0)} mm</span>
-      </div>
-      <div class="kpi-card">
-        <span class="kpi-title">Suhu Rata-rata</span>
-        <span class="kpi-value">${formatNumber(weatherKpi?.suhuAvg ?? 0)} °C</span>
+      <div class="card climate-card">
+        <div class="card-header">
+          <div>
+            <h2>Tren Kelembapan &amp; Suhu</h2>
+            <p class="muted">Rata-rata per bulan</p>
+          </div>
+          <div class="legend">
+            <span><span class="dot humidity"></span>Kelembapan (%)</span>
+            <span><span class="dot temperature"></span>Suhu (°C)</span>
+          </div>
+        </div>
+        ${renderClimateChart(weatherMonthly)}
       </div>
     </div>
-    <h2>Afdeling</h2>
-    <div class="list">
-      ${afdelings
-        .map((afdeling) => {
-          const blockCount = afdeling.blocks?.length ?? 0;
-          return `
-            <div class="list-item">
-              <div class="flex-between">
-                <div>
-                  <h3>${afdeling.nama}</h3>
-                  <p class="muted">Kode ${afdeling.kodeUnik} • ${blockCount} blok</p>
+    <div class="card">
+      <div class="section-header">
+        <h2>Monitoring Tanah</h2>
+        <p class="muted">Snapshot harian berdasarkan input mandor terakhir.</p>
+      </div>
+      <div class="soil-grid">
+        <div class="soil-card">
+          <div class="soil-meta">
+            <span class="soil-title">Curah Hujan</span>
+            ${renderStatusBadge(rainfallStatus)}
+          </div>
+          <div class="soil-value">${formatNumber(latestWeatherMonthly.curahHujanTotal ?? 0)}<span> mm/bln</span></div>
+          <p class="muted">Target 150 – 250 mm/bulan</p>
+        </div>
+        <div class="soil-card">
+          <div class="soil-meta">
+            <span class="soil-title">Kelembapan Tanah</span>
+            ${renderStatusBadge(moistureStatus)}
+          </div>
+          <div class="soil-value">${formatNumber(latestWeatherDaily.kelembapanAvg ?? 0)}<span> %</span></div>
+          <p class="muted">Ideal 28 – 35 %</p>
+        </div>
+        <div class="soil-card">
+          <div class="soil-meta">
+            <span class="soil-title">Suhu Udara</span>
+            ${renderStatusBadge(temperatureStatus)}
+          </div>
+          <div class="soil-value">${formatNumber(latestWeatherDaily.suhuAvg ?? 0)}<span> °C</span></div>
+          <p class="muted">Rentang 24 – 32 °C</p>
+        </div>
+        <div class="soil-card">
+          <div class="soil-meta">
+            <span class="soil-title">Kondisi Jalan</span>
+            ${renderStatusBadge(jalanStatus)}
+          </div>
+          <div class="soil-value">${formatNumber(jalanBaikPersentase)}<span> %</span></div>
+          <p class="muted">${formatNumber(latestWeatherDaily.jalanBaik ?? 0)} dari ${formatNumber(totalObservasi)} laporan baik</p>
+        </div>
+      </div>
+    </div>
+    <div class="card">
+      <div class="section-header">
+        <h2>Hasil Panen</h2>
+        <p class="muted">Akumulasi tonase per bulan dan snapshot harian.</p>
+      </div>
+      <div class="harvest-grid">
+        <div class="harvest-highlight">
+          <span class="harvest-label">TBS Bulan Ini</span>
+          <div class="harvest-value">${formatNumber((latestHarvestMonthly.tbsTotalKg ?? 0) / 1000)}<span> ton</span></div>
+          <p class="muted">Brondolan: ${formatNumber((latestHarvestMonthly.brondolanKg ?? 0) / 1000)} ton</p>
+          <div class="divider"></div>
+          <span class="harvest-label">Update Harian</span>
+          <p class="muted">${formatNumber(latestHarvestDaily.tbsTotalKg ?? 0)} kg TBS • ${formatNumber(latestHarvestDaily.brondolanKg ?? 0)} kg brondolan</p>
+        </div>
+        <div class="harvest-chart">
+          ${renderBarChart(harvestMonthlySeries, { unit: ' ton', highlightLatest: true })}
+        </div>
+      </div>
+    </div>
+    <div class="card">
+      <h2>Afdeling</h2>
+      <div class="list">
+        ${afdelings
+          .map((afdeling) => {
+            const blockCount = afdeling.blocks?.length ?? 0;
+            return `
+              <div class="list-item">
+                <div class="flex-between">
+                  <div>
+                    <h3>${afdeling.nama}</h3>
+                    <p class="muted">Kode ${afdeling.kodeUnik} • ${blockCount} blok</p>
+                  </div>
+                  <span class="badge">${formatNumber(afdeling.luasHa)} ha</span>
                 </div>
-                <span class="badge">${formatNumber(afdeling.luasHa)} ha</span>
+                <div class="kpi-grid">
+                  ${afdeling.blocks
+                    .map(
+                      (block) => `
+                        <div class="kpi-card">
+                          <span class="kpi-title">${block.nama}</span>
+                          <span class="kpi-value">${block.varietas ?? 'Varietas belum diisi'}</span>
+                          <span class="muted">Tahun tanam ${block.tahunTanam ?? '—'}</span>
+                        </div>
+                      `,
+                    )
+                    .join('')}
+                </div>
               </div>
-              <div class="kpi-grid">
-                ${afdeling.blocks
-                  .map(
-                    (block) => `
-                      <div class="kpi-card">
-                        <span class="kpi-title">${block.nama}</span>
-                        <span class="kpi-value">${block.varietas ?? 'N/A'}</span>
-                        <span class="muted">Tahun tanam ${block.tahunTanam ?? '—'}</span>
-                      </div>
-                    `,
-                  )
-                  .join('')}
-              </div>
-            </div>
-          `;
-        })
-        .join('')}
+            `;
+          })
+          .join('')}
+      </div>
     </div>
   `;
   toggleAuth(false);
@@ -392,6 +522,162 @@ function renderPanduan() {
       </p>
     </article>
   `;
+}
+
+function renderBarChart(items, { unit = '', highlightLatest = false } = {}) {
+  if (!items?.length) {
+    return '<div class="empty-state">Data belum tersedia</div>';
+  }
+
+  const sanitized = items.map((item) => ({
+    label: item.label ?? '',
+    value: Number.isFinite(item.value) ? item.value : 0,
+  }));
+
+  const maxValue = Math.max(...sanitized.map((item) => item.value), 0);
+  const divisor = maxValue === 0 ? 1 : maxValue;
+
+  return `
+    <div class="bar-chart">
+      ${sanitized
+        .map((item, index) => {
+          const height = Math.round((item.value / divisor) * 100);
+          const barHeight = Math.max(height, 4);
+          const latestClass = highlightLatest && index === sanitized.length - 1 ? 'latest' : '';
+          return `
+            <div class="bar">
+              <div class="bar-fill ${latestClass}" style="height: ${barHeight}%"></div>
+              <span class="bar-value">${formatNumber(item.value)}${unit}</span>
+              <span class="bar-label">${item.label}</span>
+            </div>
+          `;
+        })
+        .join('')}
+    </div>
+  `;
+}
+
+function renderClimateChart(records) {
+  if (!records?.length) {
+    return '<div class="empty-state">Data belum tersedia</div>';
+  }
+
+  const series = records.slice(-12);
+  const values = series
+    .flatMap((item) => [item.kelembapanAvg ?? null, item.suhuAvg ?? null])
+    .filter((value) => Number.isFinite(value));
+
+  if (!values.length) {
+    return '<div class="empty-state">Data belum tersedia</div>';
+  }
+
+  const width = 560;
+  const height = 220;
+  const paddingX = 36;
+  const paddingTop = 18;
+  const paddingBottom = 38;
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min || 1;
+  const step = series.length > 1 ? (width - paddingX * 2) / (series.length - 1) : 0;
+
+  const humidityPoints = [];
+  const temperaturePoints = [];
+
+  series.forEach((item, index) => {
+    const x = paddingX + step * index;
+    const humidityValue = Number.isFinite(item.kelembapanAvg) ? item.kelembapanAvg : min;
+    const temperatureValue = Number.isFinite(item.suhuAvg) ? item.suhuAvg : min;
+    const humidityY =
+      paddingTop + (1 - (humidityValue - min) / range) * (height - paddingTop - paddingBottom);
+    const temperatureY =
+      paddingTop + (1 - (temperatureValue - min) / range) * (height - paddingTop - paddingBottom);
+    humidityPoints.push(`${x.toFixed(1)},${humidityY.toFixed(1)}`);
+    temperaturePoints.push(`${x.toFixed(1)},${temperatureY.toFixed(1)}`);
+  });
+
+  if (humidityPoints.length === 1) {
+    const [x, y] = humidityPoints[0].split(',').map(Number);
+    humidityPoints.push(`${(x + 1).toFixed(1)},${y.toFixed(1)}`);
+  }
+  if (temperaturePoints.length === 1) {
+    const [x, y] = temperaturePoints[0].split(',').map(Number);
+    temperaturePoints.push(`${(x + 1).toFixed(1)},${y.toFixed(1)}`);
+  }
+
+  const axisY = height - paddingBottom;
+  const lastHumidity = humidityPoints.slice(-1)[0];
+  const lastTemperature = temperaturePoints.slice(-1)[0];
+
+  return `
+    <div class="climate-chart-wrap">
+      <svg viewBox="0 0 ${width} ${height}" class="climate-chart" preserveAspectRatio="none">
+        <defs>
+          <linearGradient id="humidityGradient" x1="0" x2="0" y1="0" y2="1">
+            <stop offset="0%" stop-color="rgba(34, 211, 238, 0.35)" />
+            <stop offset="100%" stop-color="rgba(34, 211, 238, 0.05)" />
+          </linearGradient>
+          <linearGradient id="temperatureGradient" x1="0" x2="0" y1="0" y2="1">
+            <stop offset="0%" stop-color="rgba(248, 113, 113, 0.35)" />
+            <stop offset="100%" stop-color="rgba(248, 113, 113, 0.05)" />
+          </linearGradient>
+        </defs>
+        <line x1="${paddingX}" y1="${axisY}" x2="${width - paddingX}" y2="${axisY}" class="chart-axis" />
+        <polyline points="${humidityPoints.join(' ')}" class="line humidity" />
+        <polyline points="${temperaturePoints.join(' ')}" class="line temperature" />
+        ${lastHumidity ? `<circle class="chart-point humidity" cx="${lastHumidity.split(',')[0]}" cy="${lastHumidity.split(',')[1]}" r="4" />` : ''}
+        ${lastTemperature ? `<circle class="chart-point temperature" cx="${lastTemperature.split(',')[0]}" cy="${lastTemperature.split(',')[1]}" r="4" />` : ''}
+      </svg>
+      <div class="chart-labels">
+        ${series.map((item) => `<span>${formatPeriodLabel(item.periode)}</span>`).join('')}
+      </div>
+    </div>
+  `;
+}
+
+function renderStatusBadge(status) {
+  if (!status) {
+    return '<span class="status muted">N/A</span>';
+  }
+  return `<span class="status ${status.tone}">${status.label}</span>`;
+}
+
+function classifyRange(value, { min = Number.NEGATIVE_INFINITY, max = Number.POSITIVE_INFINITY, tolerance = 0.1 } = {}) {
+  if (value == null || Number.isNaN(value)) {
+    return { label: 'Tidak ada data', tone: 'muted' };
+  }
+
+  const lower = min ?? Number.NEGATIVE_INFINITY;
+  const upper = max ?? Number.POSITIVE_INFINITY;
+  if (value >= lower && value <= upper) {
+    return { label: 'Optimal', tone: 'optimal' };
+  }
+
+  const lowerWarn = Number.isFinite(lower) ? lower * (1 - tolerance) : Number.NEGATIVE_INFINITY;
+  const upperWarn = Number.isFinite(upper) ? upper * (1 + tolerance) : Number.POSITIVE_INFINITY;
+  if (value < lowerWarn || value > upperWarn) {
+    return { label: 'Kritis', tone: 'critical' };
+  }
+
+  return { label: 'Perlu atensi', tone: 'warning' };
+}
+
+function formatPeriodLabel(periode) {
+  if (!periode) return '';
+  if (/^\d{4}-\d{2}-\d{2}$/.test(periode)) {
+    const [year, month, day] = periode.split('-').map(Number);
+    const date = new Date(Date.UTC(year, month - 1, day));
+    return date.toLocaleDateString('id-ID', { day: '2-digit', month: 'short' });
+  }
+  if (/^\d{4}-\d{2}$/.test(periode)) {
+    const [year, month] = periode.split('-').map(Number);
+    const date = new Date(Date.UTC(year, month - 1, 1));
+    return date.toLocaleDateString('id-ID', { month: 'short' });
+  }
+  if (/^\d{4}$/.test(periode)) {
+    return periode;
+  }
+  return periode;
 }
 
 function toggleAuth(showAuth) {

--- a/apps/web/public/assets/main.js
+++ b/apps/web/public/assets/main.js
@@ -1,0 +1,447 @@
+const API_BASE = window.__API_BASE__ ?? 'http://localhost:4000';
+
+const modules = [
+  { id: 'monitoring', label: 'Monitoring Kebun' },
+  { id: 'pabrik', label: 'Monitoring Pabrik' },
+  { id: 'panduan', label: 'Panduan Budidaya' },
+  { id: 'norma', label: 'Norma HK' },
+  { id: 'cost', label: 'Cost Produksi' },
+];
+
+const state = {
+  token: null,
+  user: null,
+  activeModule: 'monitoring',
+  data: {},
+};
+
+const authSection = document.getElementById('auth-section');
+const contentSection = document.getElementById('content-section');
+const navEl = document.getElementById('module-nav');
+const userBadge = document.getElementById('user-badge');
+const logoutBtn = document.getElementById('logout-btn');
+
+renderAuthForm();
+renderNav();
+updateUserBadge();
+logoutBtn.addEventListener('click', () => {
+  state.token = null;
+  state.user = null;
+  state.data = {};
+  toggleAuth(true);
+  updateUserBadge();
+});
+
+function renderAuthForm() {
+  authSection.innerHTML = `
+    <h1>Masuk ke Jamro</h1>
+    <p class="muted">Gunakan akun Mandor/Direktur atau kode pengembang sementara.</p>
+    <div class="form-grid">
+      <form id="login-form">
+        <label>Email
+          <input type="email" name="email" required placeholder="nama@contoh.com" />
+        </label>
+        <label>Password
+          <input type="password" name="password" required placeholder="••••••" />
+        </label>
+        <button class="primary" type="submit">Masuk</button>
+      </form>
+      <div class="divider"></div>
+      <form id="dev-form">
+        <label>Kode Pengembang
+          <input type="password" name="code" required placeholder="123456" />
+        </label>
+        <button class="primary" type="submit">Elevasi</button>
+      </form>
+      <div id="auth-message"></div>
+    </div>
+  `;
+
+  const loginForm = document.getElementById('login-form');
+  const devForm = document.getElementById('dev-form');
+  const message = document.getElementById('auth-message');
+
+  loginForm.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const formData = new FormData(loginForm);
+    try {
+      const result = await apiRequest('/auth/login', {
+        method: 'POST',
+        body: {
+          email: formData.get('email'),
+          password: formData.get('password'),
+        },
+      });
+      state.token = result.token;
+      state.user = result.user;
+      toggleAuth(false);
+      updateUserBadge();
+      await loadModule(state.activeModule);
+    } catch (error) {
+      message.textContent = error.message;
+      message.className = 'alert';
+    }
+  });
+
+  devForm.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const formData = new FormData(devForm);
+    try {
+      const result = await apiRequest('/auth/dev-elevate', {
+        method: 'POST',
+        body: { code: formData.get('code') },
+      });
+      state.token = result.token;
+      state.user = { id: 'dev', name: 'Pengembang', role: 'PENGEMBANG' };
+      toggleAuth(false);
+      updateUserBadge();
+      await loadModule(state.activeModule);
+    } catch (error) {
+      message.textContent = error.message;
+      message.className = 'alert';
+    }
+  });
+}
+
+function renderNav() {
+  navEl.innerHTML = '';
+  modules.forEach((module) => {
+    const button = document.createElement('button');
+    button.textContent = module.label;
+    button.classList.toggle('active', state.activeModule === module.id);
+    button.addEventListener('click', async () => {
+      if (!state.token) {
+        return;
+      }
+      state.activeModule = module.id;
+      renderNav();
+      await loadModule(module.id);
+    });
+    navEl.appendChild(button);
+  });
+}
+
+async function loadModule(moduleId) {
+  toggleAuth(false);
+  try {
+    if (moduleId === 'monitoring') {
+      await loadMonitoring();
+      renderMonitoring();
+    } else if (moduleId === 'pabrik') {
+      await loadPabrik();
+      renderPabrik();
+    } else if (moduleId === 'panduan') {
+      renderPanduan();
+    } else if (moduleId === 'norma') {
+      await loadNorma();
+      renderNorma();
+    } else if (moduleId === 'cost') {
+      await loadCost();
+      renderCost();
+    }
+  } catch (error) {
+    contentSection.innerHTML = `<div class="alert">${error.message}</div>`;
+  }
+}
+
+async function loadMonitoring() {
+  const [afdelings, harvest, weather] = await Promise.all([
+    apiRequest('/afdelings'),
+    apiRequest('/harvest/aggregate?periode=day'),
+    apiRequest('/metrics/kebun?periode=day'),
+  ]);
+  state.data.monitoring = { afdelings, harvest, weather };
+}
+
+function renderMonitoring() {
+  const { afdelings = [], harvest = [], weather = [] } = state.data.monitoring ?? {};
+  const harvestKpi = harvest.slice(-1)[0];
+  const weatherKpi = weather.slice(-1)[0];
+  contentSection.innerHTML = `
+    <div class="module-header">
+      <div>
+        <h1>Monitoring Kebun</h1>
+        <p class="muted">Percepatan waktu aktif, data terbaru diperbarui otomatis.</p>
+      </div>
+      <div class="filters">
+        <span class="badge">Sim 1 hari = 30 detik</span>
+      </div>
+    </div>
+    <div class="kpi-grid">
+      <div class="kpi-card">
+        <span class="kpi-title">TBS Hari Ini</span>
+        <span class="kpi-value">${formatNumber(harvestKpi?.tbsTotalKg ?? 0)} kg</span>
+      </div>
+      <div class="kpi-card">
+        <span class="kpi-title">Brondolan</span>
+        <span class="kpi-value">${formatNumber(harvestKpi?.brondolanKg ?? 0)} kg</span>
+      </div>
+      <div class="kpi-card">
+        <span class="kpi-title">Curah Hujan Rata-rata</span>
+        <span class="kpi-value">${formatNumber(weatherKpi?.curahHujanAvg ?? 0)} mm</span>
+      </div>
+      <div class="kpi-card">
+        <span class="kpi-title">Suhu Rata-rata</span>
+        <span class="kpi-value">${formatNumber(weatherKpi?.suhuAvg ?? 0)} °C</span>
+      </div>
+    </div>
+    <h2>Afdeling</h2>
+    <div class="list">
+      ${afdelings
+        .map((afdeling) => {
+          const blockCount = afdeling.blocks?.length ?? 0;
+          return `
+            <div class="list-item">
+              <div class="flex-between">
+                <div>
+                  <h3>${afdeling.nama}</h3>
+                  <p class="muted">Kode ${afdeling.kodeUnik} • ${blockCount} blok</p>
+                </div>
+                <span class="badge">${formatNumber(afdeling.luasHa)} ha</span>
+              </div>
+              <div class="kpi-grid">
+                ${afdeling.blocks
+                  .map(
+                    (block) => `
+                      <div class="kpi-card">
+                        <span class="kpi-title">${block.nama}</span>
+                        <span class="kpi-value">${block.varietas ?? 'N/A'}</span>
+                        <span class="muted">Tahun tanam ${block.tahunTanam ?? '—'}</span>
+                      </div>
+                    `,
+                  )
+                  .join('')}
+              </div>
+            </div>
+          `;
+        })
+        .join('')}
+    </div>
+  `;
+  toggleAuth(false);
+}
+
+async function loadPabrik() {
+  const [stations, aggregate] = await Promise.all([
+    apiRequest('/pabrik/stations'),
+    apiRequest('/pabrik/aggregate?periode=day'),
+  ]);
+  state.data.pabrik = { stations, aggregate };
+}
+
+function renderPabrik() {
+  const { stations = [], aggregate = [] } = state.data.pabrik ?? {};
+  const last = aggregate.slice(-1)[0];
+  contentSection.innerHTML = `
+    <div class="module-header">
+      <div>
+        <h1>Monitoring Pabrik</h1>
+        <p class="muted">Rekap throughput, rendemen, dan losses per stasiun.</p>
+      </div>
+      <div class="filters">
+        <span class="badge">OEE Simulasi</span>
+      </div>
+    </div>
+    <div class="kpi-grid">
+      <div class="kpi-card">
+        <span class="kpi-title">Throughput Rata-rata</span>
+        <span class="kpi-value">${formatNumber(last?.throughputAvg ?? 0)} tph</span>
+      </div>
+      <div class="kpi-card">
+        <span class="kpi-title">Rendemen CPO</span>
+        <span class="kpi-value">${formatNumber(last?.rendemenCpoAvg ?? 0)} %</span>
+      </div>
+      <div class="kpi-card">
+        <span class="kpi-title">Energi Harian</span>
+        <span class="kpi-value">${formatNumber(last?.energiTotal ?? 0)} kWh</span>
+      </div>
+    </div>
+    <h2>Stasiun</h2>
+    <div class="list">
+      ${stations
+        .flatMap((pabrik) =>
+          pabrik.stations.map(
+            (station) => `
+              <div class="list-item">
+                <div class="flex-between">
+                  <div>
+                    <h3>${station.nama}</h3>
+                    <p class="muted">Pabrik ${pabrik.nama}</p>
+                  </div>
+                  <span class="badge">Urutan ${station.urutan}</span>
+                </div>
+                <p class="muted">Pantau metrik detail via API /pabrik/stations/${station.id}/metrics</p>
+              </div>
+            `,
+          ),
+        )
+        .join('')}
+    </div>
+  `;
+}
+
+async function loadNorma() {
+  const norma = await apiRequest('/norma-hk');
+  state.data.norma = norma;
+}
+
+function renderNorma() {
+  const { norma = [] } = state.data;
+  const canEdit = ['DIREKTUR', 'PENGEMBANG'].includes(state.user?.role);
+  contentSection.innerHTML = `
+    <div class="module-header">
+      <div>
+        <h1>Norma Hari Kerja</h1>
+        <p class="muted">Parameter dasar perhitungan HK dan payroll.</p>
+      </div>
+      ${canEdit ? '<span class="badge">Mode edit diizinkan</span>' : ''}
+    </div>
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Pekerjaan</th>
+          <th>Norma HK</th>
+          <th>Satuan</th>
+          <th>Catatan</th>
+          <th>Update</th>
+        </tr>
+      </thead>
+      <tbody>
+        ${norma
+          .map(
+            (item) => `
+              <tr>
+                <td>${item.pekerjaan}</td>
+                <td>${item.normaHk}</td>
+                <td>${item.satuan}</td>
+                <td>${item.catatan ?? ''}</td>
+                <td>${new Date(item.updatedAt).toLocaleString('id-ID')}</td>
+              </tr>
+            `,
+          )
+          .join('')}
+      </tbody>
+    </table>
+  `;
+}
+
+async function loadCost() {
+  const summary = await apiRequest('/cost/summary');
+  state.data.cost = summary;
+}
+
+function renderCost() {
+  const { cost = [] } = state.data;
+  contentSection.innerHTML = `
+    <div class="module-header">
+      <div>
+        <h1>Ringkasan Biaya Produksi</h1>
+        <p class="muted">Kalkulasi kategori biaya dari feed simulasi.</p>
+      </div>
+    </div>
+    <div class="list">
+      ${cost
+        .map(
+          (item) => `
+            <div class="list-item">
+              <div class="flex-between">
+                <h3>${item.kategori}</h3>
+                <span class="badge">Total Rp ${formatNumber(item.total)}</span>
+              </div>
+              <ul>
+                ${item.items
+                  .map((detail) => `<li>${detail.uraian} • Rp ${formatNumber(detail.hargaSatuan)} / ${detail.satuan}</li>`)
+                  .join('')}
+              </ul>
+            </div>
+          `,
+        )
+        .join('')}
+    </div>
+  `;
+}
+
+function renderPanduan() {
+  contentSection.innerHTML = `
+    <div class="module-header">
+      <div>
+        <h1>Panduan Budidaya</h1>
+        <p class="muted">Kurasi internal yang siap diintegrasi dengan CMS ringan.</p>
+      </div>
+    </div>
+    <article class="list-item">
+      <h3>1. Persiapan Lahan &amp; Pembibitan</h3>
+      <p>
+        Gunakan bibit bersertifikat varietas tenera dengan tingkat kecambah &gt; 95%. Pastikan pH tanah pada kisaran 4.5 - 6.0 dan lakukan
+        penanaman penutup tanah leguminosa untuk menjaga kelembapan.
+      </p>
+      <h3>2. Pemeliharaan Blok</h3>
+      <p>
+        Monitoring curah hujan, suhu, dan kelembapan tanah diintegrasikan otomatis dari input mandor. Sistem akan memberi peringatan
+        jika curah hujan &lt; 5 mm atau suhu &gt; 34 °C untuk lebih dari dua hari simulasi berturut-turut.
+      </p>
+      <h3>3. Panen &amp; Transportasi</h3>
+      <p>
+        Jadwalkan panen berdasarkan umur brondolan dan estimasi produksi per blok. Gunakan kode unik blok saat membuat SPB agar data
+        ritase dan tonase terhubung ke dashboard monitoring.
+      </p>
+      <h3>4. Integrasi Norma HK</h3>
+      <p>
+        Norma HK menjadi acuan payroll otomatis. Direktur dapat melakukan revisi melalui modul Norma HK dan histori perubahan
+        tersimpan pada backend.
+      </p>
+    </article>
+  `;
+}
+
+function toggleAuth(showAuth) {
+  if (showAuth) {
+    authSection.classList.remove('hidden');
+    contentSection.classList.add('hidden');
+  } else {
+    authSection.classList.add('hidden');
+    contentSection.classList.remove('hidden');
+  }
+}
+
+function updateUserBadge() {
+  if (!state.user) {
+    userBadge.textContent = 'Belum masuk';
+    return;
+  }
+  userBadge.innerHTML = `Login sebagai <strong>${state.user.name}</strong> • ${state.user.role}`;
+}
+
+async function apiRequest(path, { method = 'GET', body } = {}) {
+  const headers = {};
+  if (body) {
+    headers['Content-Type'] = 'application/json';
+  }
+  if (state.token) {
+    headers.Authorization = `Bearer ${state.token}`;
+  }
+  const response = await fetch(`${API_BASE}${path}`, {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const contentType = response.headers.get('content-type') ?? '';
+  const payload = contentType.includes('application/json') ? await response.json() : null;
+  if (!response.ok) {
+    const message = payload?.message ?? 'Terjadi kesalahan';
+    throw new Error(message);
+  }
+  return payload?.data ?? payload ?? null;
+}
+
+function formatNumber(value) {
+  return new Intl.NumberFormat('id-ID', { maximumFractionDigits: 2 }).format(value ?? 0);
+}
+
+if (!!window.EventSource) {
+  const stream = new EventSource(`${API_BASE}/live`);
+  stream.addEventListener('tick', (event) => {
+    const data = JSON.parse(event.data);
+    document.title = `Jamro • ${new Date(data.now).toLocaleString('id-ID')}`;
+  });
+}

--- a/apps/web/public/index.html
+++ b/apps/web/public/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="id">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Jamro Palm Monitoring</title>
+    <link rel="stylesheet" href="/assets/main.css" />
+  </head>
+  <body>
+    <div id="app" class="app">
+      <aside class="sidebar">
+        <div class="brand">Jamro</div>
+        <nav id="module-nav" class="nav"></nav>
+        <div id="user-badge" class="user-badge"></div>
+        <button id="logout-btn" class="logout-btn" type="button">Keluar</button>
+      </aside>
+      <main class="content">
+        <section id="auth-section" class="card"></section>
+        <section id="content-section" class="card hidden"></section>
+      </main>
+    </div>
+    <script type="module" src="/assets/main.js"></script>
+  </body>
+</html>

--- a/apps/web/server.js
+++ b/apps/web/server.js
@@ -1,0 +1,38 @@
+import http from 'node:http';
+import { createReadStream, statSync, existsSync } from 'node:fs';
+import { join, extname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const PUBLIC_DIR = join(__dirname, 'public');
+const PORT = Number.parseInt(process.env.WEB_PORT ?? '5173', 10);
+const HOST = process.env.WEB_HOST ?? '0.0.0.0';
+
+const MIME_TYPES = {
+  '.html': 'text/html',
+  '.js': 'application/javascript',
+  '.css': 'text/css',
+  '.json': 'application/json',
+  '.svg': 'image/svg+xml',
+};
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  let filePath = join(PUBLIC_DIR, url.pathname);
+  if (url.pathname === '/' || url.pathname === '') {
+    filePath = join(PUBLIC_DIR, 'index.html');
+  }
+  if (!existsSync(filePath)) {
+    res.writeHead(404);
+    res.end('Not Found');
+    return;
+  }
+  const ext = extname(filePath);
+  const contentType = MIME_TYPES[ext] ?? 'application/octet-stream';
+  res.writeHead(200, { 'Content-Type': contentType });
+  createReadStream(filePath).pipe(res);
+});
+
+server.listen(PORT, HOST, () => {
+  console.log(`Web server running at http://${HOST}:${PORT}`);
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "jamro",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Palm oil estate and mill monitoring platform",
+  "packageManager": "npm@10.7.0",
+  "workspaces": [
+    "apps/*",
+    "packages/*"
+  ],
+  "scripts": {
+    "dev:web": "npm --workspace apps/web run dev",
+    "dev:api": "npm --workspace apps/api run start:dev",
+    "lint": "npm run lint --workspaces",
+    "build": "npm run build --workspaces",
+    "test": "npm run test --workspaces"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://example.com/palm-oil-monitoring"
+  }
+}


### PR DESCRIPTION
## Summary
- create a monorepo layout with separate api and web workspaces
- implement an in-memory Nest-free API with JWT auth, RBAC, simulation feeds, and SSE updates
- build a static dashboard consuming the API and refresh the README with usage instructions

## Testing
- npm run lint --workspaces
- npm run build --workspaces
- npm run test --workspaces

------
https://chatgpt.com/codex/tasks/task_b_6900f208de008329b61def5d4498ed77